### PR TITLE
Multi parallel plots

### DIFF
--- a/cave/plot/parallel_coordinates.py
+++ b/cave/plot/parallel_coordinates.py
@@ -270,6 +270,7 @@ class ParallelCoordinatesPlotter(object):
                          range(num_ticks + 1)]
             ax.yaxis.set_ticks(ticks)
             ax.set_yticklabels(tick_labels)
+            ax.set_ylim([-0.05, 1.05])
 
         # TODO adjust tick-labels to unused and maybe even log?
         for p, ax in enumerate(axes):

--- a/cave/plot/parallel_coordinates.py
+++ b/cave/plot/parallel_coordinates.py
@@ -10,6 +10,7 @@ plt.style.use(os.path.join(os.path.dirname(__file__), 'mpl_style'))
 from matplotlib import ticker
 import matplotlib.colors as colors
 import matplotlib.cm as cmx
+import matplotlib.patheffects as path_efx
 
 from ConfigSpace.util import impute_inactive_values
 from ConfigSpace.hyperparameters import CategoricalHyperparameter, IntegerHyperparameter
@@ -242,10 +243,15 @@ class ParallelCoordinatesPlotter(object):
                 cval = scale.to_rgba(self._fun(self.validated_rh.get_cost(configs[idx]), logy))
                 cval = (cval[2], cval[0], cval[1])
                 if configs[idx] == self.best_config_performance:
-                    cval=(0., 0., 0.)
-                alpha = 1. #  self.get_alpha(configs[idx])
+                    cval = (0., 0., 0.)
+                alpha = 0.6
+                zorder = idx - 5 if idx > len(data) // 2 else len(data) - idx  # -5 to have the best on top of the worst
+                path_effects = [path_efx.Normal()]
+                if idx in [0, 1, 2, 3, 4, len(data) - 1, len(data) - 2, len(data) - 3, len(data) - 4, len(data) - 5]:
+                    alpha = 1
+                    path_effects = [path_efx.withStroke(linewidth=5, foreground='k')]
                 ax.plot(range(len(params)), data.loc[idx, params], color=cval,
-                        alpha=alpha, linewidth=3, zorder=int(cval[2]*255))
+                        alpha=alpha, linewidth=3, zorder=zorder, path_effects=path_effects)
             ax.set_xlim([i, i + 1])
 
         def set_ticks_for_axis(p, ax, num_ticks=10):

--- a/cave/plot/parallel_coordinates.py
+++ b/cave/plot/parallel_coordinates.py
@@ -1,6 +1,7 @@
 import os
 import math
 import logging
+import random
 
 import numpy as np
 import pandas as pd
@@ -112,6 +113,10 @@ class ParallelCoordinatesPlotter(object):
                                             in all_configs])
         self.worst_config_performance = max([self.validated_rh.get_cost(c) for c
                                              in all_configs])
+        ids = list(sorted(random.sample(range(len(configs_to_plot)), num_configs)))
+        ids[0] = 0
+        ids[-1] = len(configs_to_plot) - 1
+        self._plot(np.array(configs_to_plot)[ids], params, fn=os.path.join(self.output_dir,"parallel_coordinates_uniform_" + str(len(ids)) + '.png'))
         if num_configs < len(configs_to_plot):  # Only sample on the logscale if not all configs are plotted.
             ids = self._get_log_spaced_ids(configs_to_plot, num_configs)
         else:
@@ -119,7 +124,7 @@ class ParallelCoordinatesPlotter(object):
         configs_to_plot = np.array(configs_to_plot)[ids]
         return self._plot(configs_to_plot, params)
 
-    def _plot(self, configs, params):
+    def _plot(self, configs, params, fn=None):
         """
         Parameters
         ----------
@@ -131,8 +136,12 @@ class ParallelCoordinatesPlotter(object):
         -------
         output: str
         """
-        filename = os.path.join(self.output_dir,
-                                "parallel_coordinates_" + str(len(configs)) + '.png')
+        if fn is None:
+            filename = os.path.join(self.output_dir,
+                                    "parallel_coordinates_" + str(len(configs)) + '.png')
+        else:
+            filename = fn
+
         if len(params) < 3:
             self.logger.info("Only two parameters, skipping parallel coordinates.")
             return
@@ -215,6 +224,8 @@ class ParallelCoordinatesPlotter(object):
             for idx in data.index:  # Iterate over configs
                 cval = scale.to_rgba(self.validated_rh.get_cost(configs[idx]))
                 cval = (cval[2], cval[0], cval[1])
+                if configs[idx] == self.best_config_performance:
+                    cval=(0., 0., 0.)
                 alpha = 1. #  self.get_alpha(configs[idx])
                 ax.plot(range(len(params)), data.loc[idx, params], color=cval,
                         alpha=alpha, linewidth=3, zorder=int(cval[2]*255))

--- a/cave/plot/parallel_coordinates.py
+++ b/cave/plot/parallel_coordinates.py
@@ -242,8 +242,6 @@ class ParallelCoordinatesPlotter(object):
             for idx in data.index:  # Iterate over configs
                 cval = scale.to_rgba(self._fun(self.validated_rh.get_cost(configs[idx]), logy))
                 cval = (cval[2], cval[0], cval[1])
-                if configs[idx] == self.best_config_performance:
-                    cval = (0., 0., 0.)
                 alpha = 0.6
                 zorder = idx - 5 if idx > len(data) // 2 else len(data) - idx  # -5 to have the best on top of the worst
                 path_effects = [path_efx.Normal()]

--- a/cave/plot/parallel_coordinates.py
+++ b/cave/plot/parallel_coordinates.py
@@ -113,18 +113,26 @@ class ParallelCoordinatesPlotter(object):
                                             in all_configs])
         self.worst_config_performance = max([self.validated_rh.get_cost(c) for c
                                              in all_configs])
-        ids = list(sorted(random.sample(range(len(configs_to_plot)), num_configs)))
-        ids[0] = 0
-        ids[-1] = len(configs_to_plot) - 1
-        self._plot(np.array(configs_to_plot)[ids], params, fn=os.path.join(self.output_dir,"parallel_coordinates_uniform_" + str(len(ids)) + '.png'))
+        if num_configs < len(configs_to_plot):
+            ids = list(sorted(random.sample(range(len(configs_to_plot)), num_configs)))
+            ids[0] = 0
+            ids[-1] = len(configs_to_plot) - 1
+        else:
+            ids = list(range(len(configs_to_plot)))
+        self._plot(np.array(configs_to_plot)[ids], params, log_c=False,
+                   fn=os.path.join(self.output_dir, "parallel_coordinates_uniform_" + str(len(ids)) + '.png'))
+        self._plot(np.array(configs_to_plot)[ids], params, log_c=True,
+                   fn=os.path.join(self.output_dir, "parallel_coordinates_uniform_logged_c" + str(len(ids)) + '.png'))
         if num_configs < len(configs_to_plot):  # Only sample on the logscale if not all configs are plotted.
             ids = self._get_log_spaced_ids(configs_to_plot, num_configs)
         else:
             ids = range(len(all_configs))
         configs_to_plot = np.array(configs_to_plot)[ids]
+        self._plot(configs_to_plot, params, log_c=False,
+                   fn=os.path.join(self.output_dir, "parallel_coordinates_unlogged_c" + str(len(ids)) + '.png'))
         return self._plot(configs_to_plot, params)
 
-    def _plot(self, configs, params, fn=None):
+    def _plot(self, configs, params, fn=None, log_c=True):
         """
         Parameters
         ----------
@@ -211,12 +219,13 @@ class ParallelCoordinatesPlotter(object):
 
         # setup colormap
         cm = plt.get_cmap('winter')
+        scaler = colors.LogNorm if log_c else colors.Normalize
         if self.worst_config_performance < self.best_config_performance:
-            normedC = colors.Normalize(vmin=self.worst_config_performance,
-                                       vmax=self.best_config_performance)
+            normedC = scaler(vmin=self.worst_config_performance,
+                             vmax=self.best_config_performance)
         else:
-            normedC = colors.Normalize(vmax=self.worst_config_performance,
-                                       vmin=self.best_config_performance)
+            normedC = scaler(vmax=self.worst_config_performance,
+                             vmin=self.best_config_performance)
         scale = cmx.ScalarMappable(norm=normedC, cmap=cm)
 
         # Plot data


### PR DESCRIPTION
Working on making the parallel plots more informative.
Based on suggestions by @shukon to uniformly sample the configurations to plot and also to put the colorscheme on log-scale.

Difference in logarithmic sampling and uniform sampling:
logarithmic
![parallel_coordinates_999](https://user-images.githubusercontent.com/8221789/34671837-55b54834-f47c-11e7-8b82-fab4c5899ee2.png)

uniform
![parallel_coordinates_uniform_1000](https://user-images.githubusercontent.com/8221789/34671843-5c316940-f47c-11e7-842a-b8e2fa408789.png)

As you can see, uniform sampling is not advantageous if there is one bad configuration that "dominates" the color spectrum.

Difference for color scheme (on a much smaller example):
logarithmic
![parallel_coordinates_unlogged78](https://user-images.githubusercontent.com/8221789/34671958-e57681fe-f47c-11e7-9029-c9895a086019.png)

uniform
![parallel_coordinates_unlogged_c78](https://user-images.githubusercontent.com/8221789/34671960-e9ebf584-f47c-11e7-9d87-a6d10f52922b.png)

Currently, all versions of the plot are generated, however the plot with logarithmic sampling of the configurations to plot, as well as logarithmic color-scheme is linked in the report.

In my mind, logarithmic-logarithmic is the way to go to make the parallel plots as informative as possible.