### PR TITLE
Algo footprints

### DIFF
--- a/cave/plot/algorithm_footprint.py
+++ b/cave/plot/algorithm_footprint.py
@@ -255,7 +255,7 @@ class AlgorithmFootprint(object):
             zorder = 1
             alpha = 1
             if len_longest < idx:  # if we plot points from the shorter list, increase zorder and use small alpha
-                alpha = 0.25
+                alpha = 0.375
                 zorder=9999
             plt.scatter(coords[0], coords[1], color=(r, g, b), s=15, zorder=zorder, alpha=alpha)
         ax.set_ylabel('principal component 1')

--- a/cave/plot/algorithm_footprint.py
+++ b/cave/plot/algorithm_footprint.py
@@ -263,7 +263,6 @@ class AlgorithmFootprint(object):
         plt.tight_layout()
         fig.savefig(out)
         plt.close(fig)
-        print('#'*120)
         return out
 
 #### Below not implemented """


### PR DESCRIPTION
Work on fixing the overlapping points problem caused by points lying too close together after PCA transformation.

If we have points like 0.0001 and 0.001 on an x-axis with range 0-10, we won't be able to distinguish between the two points when plotted. Thus this fix rounds all floats to 1 decimal point. After that step we can count if there are multiple points with the same coordinates (using pandas). The counts can than be used to compute a red and green part of the point to plot. Thus we can see if a coordinate maps to distinct different values.

Additionally I change the plotting order, such that the shorter of the two lists to plot is plotted last, as the short list is unlikely to shadow many points from the long list. For the points in the short list, alpha is decreased but the zorder is increased.

Thus all points (even if they partly overlap) should be visible in some shading.
Example plot for default:
![default](https://user-images.githubusercontent.com/8221789/34721018-609b3946-f541-11e7-99cc-d3991022b81e.png)

and incumbent:
![incumbent](https://user-images.githubusercontent.com/8221789/34721029-69a41f80-f541-11e7-8179-0d3aa446044c.png)

Looking at the second plot, I'm not 100% sure if the labeling performs correctly in this case. Could you check that @shukon?

What do you think @mlindauer? Does this approach suffice?
  