### PR TITLE
ADD pimp-table

### DIFF
--- a/cave/analyzer.py
+++ b/cave/analyzer.py
@@ -45,7 +45,8 @@ class Analyzer(object):
     """
 
     def __init__(self, original_rh, validated_rh, default, incumbent,
-                 train_test, scenario, validator, output, max_pimp_samples, fanova_pairwise=True):
+                 train_test, scenario, validator, output, max_pimp_samples,
+                 fanova_pairwise=True):
         """
         Parameters
         ----------
@@ -459,17 +460,31 @@ class Analyzer(object):
         self.evaluators.append(self.pimp.evaluator)
         return self.pimp
 
-    def importance_table(self):
+    def importance_table(self, pimp_sort_table_by):
         """Create a html-table over all evaluated parameter-importance-methods.
         Parameters are sorted after their average importance."""
         parameters = [p.name for p in self.scenario.cs.get_hyperparameters()]
         index, values, columns = [], [], []
         columns = [e.name for e in self.evaluators]
-        # Sort parameters after average importance
-        p_avg = {p : np.mean([e.evaluated_parameter_importance[p] for e in self.evaluators
-                    if p in e.evaluated_parameter_importance]) for p in parameters}
-        p_avg = {p : 0 if np.isnan(v) else v for p, v in p_avg.items()}
-        p_order = sorted(parameters, key=lambda p: p_avg[p], reverse=True)
+        columns_lower = [c.lower() for c in columns]
+        self.logger.debug("Sort pimp-table by %s" % pimp_sort_table_by)
+        if pimp_sort_table_by == "average":
+            # Sort parameters after average importance
+            p_avg = {p : np.mean([e.evaluated_parameter_importance[p] for e in self.evaluators
+                        if p in e.evaluated_parameter_importance]) for p in parameters}
+            p_avg = {p : 0 if np.isnan(v) else v for p, v in p_avg.items()}
+            p_order = sorted(parameters, key=lambda p: p_avg[p], reverse=True)
+        elif pimp_sort_table_by in columns_lower:
+            def __get_key(p):
+                imp = self.evaluators[columns_lower.index(pimp_sort_table_by)].evaluated_parameter_importance
+                return imp[p] if p in imp else 0
+            p_order = sorted(parameters,
+                             key=__get_key,
+                             reverse=True)
+        else:
+            raise ValueError("Trying to sort importance table after {}, which "
+                             "was not evaluated.".format(pimp_sort_table_by))
+
         # Only add parameters where at least one evaluator shows importance > 0.05
         for p in p_order:
             values_for_p = []

--- a/cave/cave_cli.py
+++ b/cave/cave_cli.py
@@ -36,6 +36,7 @@ class CaveCLI(object):
                      "lpi",
                      "none"
         ]
+        p_sort_by_choices = ["average"] + p_choices[1:-1]
         f_choices = [
                      "all",
                      "box_violin",
@@ -88,6 +89,11 @@ class CaveCLI(object):
                               action="store_false",
                               dest="fanova_pairwise",
                               help="fANOVA won't compute pairwise marginals")
+        opt_opts.add_argument("--pimp_sort_table_by",
+                              default="average",
+                              choices=p_sort_by_choices,
+                              help="raw|what kind of parameter importance method to "
+                                   "use to sort the overview-table.")
         opt_opts.add_argument("--param_importance",
                               default="all",
                               nargs='+',
@@ -149,6 +155,11 @@ class CaveCLI(object):
         else:
             param_imp = args_.param_importance
 
+        if not (args_.pimp_sort_table_by == "average" or
+                args_.pimp_sort_table_by in param_imp):
+            raise ValueError("Pimp comparison sorting key is {}, but this "
+                             "method is deactivated.".format(args_.pimp_sort_table_by))
+
         if "all" in args_.feat_analysis:
             feature_analysis = ["box_violin", "correlation", "importance",
                                 "clustering", "feature_cdf"]
@@ -177,7 +188,8 @@ class CaveCLI(object):
         cave = CAVE(folders, args_.output, args_.ta_exec_dir,
                     missing_data_method=args_.validation,
                     max_pimp_samples=args_.max_pimp_samples,
-                    fanova_pairwise=args_.fanova_pairwise)
+                    fanova_pairwise=args_.fanova_pairwise,
+                    pimp_sort_table_by=args_.pimp_sort_table_by)
 
         # Analyze
         cave.analyze(performance=args_.tabular_analysis,

--- a/cave/cavefacade.py
+++ b/cave/cavefacade.py
@@ -403,21 +403,9 @@ class CAVE(object):
             of = os.path.join(self.output, 'pimp.tex')
             self.logger.info('Creating pimp latex table at %s' % of)
             self.analyzer.pimp.table_for_comparison(self.analyzer.evaluators, of, style='latex')
-            # Hack until supported by pimp-package (or if denied, properly
-            # implemented here): write to file, parse, turn into table
-            of = os.path.join(self.output, 'pimp_table.txt')
-            self.analyzer.pimp.table_for_comparison(self.analyzer.evaluators, of, style='cmd')
-            with open(of, 'r') as fh:
-                lines = list(fh.readlines())
-            columns = [name.strip() for name in lines[0].split('|')][1:]
-            values = [[v.strip() for v in line.split('|')] for line in lines[2:-2]]
-            index = [l[0] for l in values]
-            values = [l[1:] for l in values]
 
-            comp_table = DataFrame(values, columns=columns, index=index)
-            comp_table = comp_table.to_html()
-            self.website["Parameter Importance"]["Table"] = {
-                "table": comp_table}
+            table = self.analyzer.importance_table()
+            self.website["Parameter Importance"]["Table"] = {"table" : table}
             self.website["Parameter Importance"].move_to_end("Table", last=False)
 
 

--- a/cave/cavefacade.py
+++ b/cave/cavefacade.py
@@ -403,6 +403,22 @@ class CAVE(object):
             of = os.path.join(self.output, 'pimp.tex')
             self.logger.info('Creating pimp latex table at %s' % of)
             self.analyzer.pimp.table_for_comparison(self.analyzer.evaluators, of, style='latex')
+            # Hack until supported by pimp-package (or if denied, properly
+            # implemented here): write to file, parse, turn into table
+            of = os.path.join(self.output, 'pimp_table.txt')
+            self.analyzer.pimp.table_for_comparison(self.analyzer.evaluators, of, style='cmd')
+            with open(of, 'r') as fh:
+                lines = list(fh.readlines())
+            columns = [name.strip() for name in lines[0].split('|')][1:]
+            values = [[v.strip() for v in line.split('|')] for line in lines[2:-2]]
+            index = [l[0] for l in values]
+            values = [l[1:] for l in values]
+
+            comp_table = DataFrame(values, columns=columns, index=index)
+            comp_table = comp_table.to_html()
+            self.website["Parameter Importance"]["Table"] = {
+                "table": comp_table}
+            self.website["Parameter Importance"].move_to_end("Table", last=False)
 
 
     def feature_analysis(self, box_violin=False, correlation=False,

--- a/cave/cavefacade.py
+++ b/cave/cavefacade.py
@@ -57,7 +57,8 @@ class CAVE(object):
 
     def __init__(self, folders: typing.List[str], output: str,
                  ta_exec_dir: Union[str, None]=None, missing_data_method: str='epm',
-                 max_pimp_samples: int=-1, fanova_pairwise=True):
+                 max_pimp_samples: int=-1, fanova_pairwise=True,
+                 pimp_sort_table_by="average"):
         """
         Initialize CAVE facade to handle analyzing, plotting and building the
         report-page easily. During initialization, the analysis-infrastructure
@@ -161,9 +162,12 @@ class CAVE(object):
                                  self.scenario, self.validator, self.output,
                                  max_pimp_samples, fanova_pairwise)
 
+        self.pimp_sort_table_by = pimp_sort_table_by
+
         self.builder = HTMLBuilder(self.output, "CAVE")
         # Builder for html-website
         self.website = OrderedDict([])
+
 
     def complete_data(self, method="epm"):
         """Complete missing data of runs to be analyzed. Either using validation
@@ -404,9 +408,16 @@ class CAVE(object):
             self.logger.info('Creating pimp latex table at %s' % of)
             self.analyzer.pimp.table_for_comparison(self.analyzer.evaluators, of, style='latex')
 
-            table = self.analyzer.importance_table()
-            self.website["Parameter Importance"]["Table"] = {"table" : table}
-            self.website["Parameter Importance"].move_to_end("Table", last=False)
+            table = self.analyzer.importance_table(self.pimp_sort_table_by)
+            self.website["Parameter Importance"]["Importance Table"] = {
+                    "table" : table,
+                    "tooltip" : "Parameters are sorted by the {} "
+                                "importance-value. Note, that the values are not "
+                                "directly comparable, since the different techniques "
+                                "provide different metrics (see respective tooltips "
+                                "for details on the differences).".format(
+                                    self.pimp_sort_table_by)}
+            self.website["Parameter Importance"].move_to_end("Importance Table", last=False)
 
 
     def feature_analysis(self, box_violin=False, correlation=False,

--- a/test/test_cli/test_cli.py
+++ b/test/test_cli/test_cli.py
@@ -100,3 +100,15 @@ class TestCLI(unittest.TestCase):
                 testargs.extend(["--ta_exec", "examples/spear_qcp_small/"])
                 with mock.patch.object(sys, 'argv', testargs):
                     self.assertRaises(ValueError, self.cavecli.main_cli)
+
+    def test_exceptions(self):
+        test_folder = "examples/spear_qcp_small/example_output/run_1"
+
+        testargs = ["python", "scripts/cave",
+                    "--folders", test_folder,
+                    "--ta_exec", "examples/spear_qcp_small/",
+                    "--pimp_sort_table_by", "fanova",
+                    "--param_importance", "ablation"]
+        # No ta_exec -> scenario cannot be loaded
+        with mock.patch.object(sys, 'argv', testargs):
+            self.assertRaises(ValueError, self.cavecli.main_cli)


### PR DESCRIPTION
Addressing #104.
Adding a hacky version of the pimp-comparison table. It is dependent on the layout of the cmd-line table of the pimp-package, but before creating a "proper" table within CAVE I'd wait whether https://github.com/automl/ParameterImportance/issues/67 gets accepted. Or @AndreBiedenkapp maybe there is an easy way to just grab all the values from the importance-object somehow?