### PR TITLE
Fixes meeting 01 03

### DIFF
--- a/cave/analyzer.py
+++ b/cave/analyzer.py
@@ -246,8 +246,8 @@ class Analyzer(object):
                                round(def_par1[1], dec_place),
                                round(inc_par1[1], dec_place)],
                               ["{}/{}".format(def_timeout[0][0], def_timeout[0][1]),
-                               "{}/{}".format(def_timeout[1][0], def_timeout[1][1]),
                                "{}/{}".format(inc_timeout[0][0], inc_timeout[0][1]),
+                               "{}/{}".format(def_timeout[1][0], def_timeout[1][1]),
                                "{}/{}".format(inc_timeout[1][0], inc_timeout[1][1])
                                ]])
             df = DataFrame(data=array, index=['PAR10', 'PAR1', 'Timeouts'],

--- a/cave/cavefacade.py
+++ b/cave/cavefacade.py
@@ -149,7 +149,7 @@ class CAVE(object):
         # Estimate missing costs for [def, inc1, inc2, ...]
         self.complete_data(method=missing_data_method)
         self.best_run = min(self.runs, key=lambda run:
-                self.validated_rh.get_cost(run.solver.incumbent))
+                            self.validated_rh.get_cost(run.solver.incumbent))
 
         self.default = self.scenario.cs.get_default_configuration()
         self.incumbent = self.best_run.solver.incumbent
@@ -163,7 +163,7 @@ class CAVE(object):
                                self.scenario.test_insts != [None])
 
         self.analyzer = Analyzer(self.original_rh, self.validated_rh,
-                                 self.default, self.incumbent, self.train_test,
+                                 self.best_run, self.train_test,
                                  self.scenario, self.validator, self.output,
                                  max_pimp_samples, fanova_pairwise,
                                  rng=self.rng)

--- a/cave/plot/configurator_footprint.py
+++ b/cave/plot/configurator_footprint.py
@@ -436,9 +436,11 @@ class ConfiguratorFootprint(object):
         default = conf_list[0].configuration_space.get_default_configuration()
         conf_types = ["Default" if c == default else "Final Incumbent" if c == inc_list[-1]
                       else "Incumbent" if c in inc_list else "Candidate" for c in conf_list]
+        # We group "Local Search" and "Random Search (sorted)" both into local
         origins = ["Unknown" if not c.origin else
-                   "Random" if c.origin.startswith("Random") else
-                   "Local" if c.origin.startswith("Local") else
+                   "Random" if c.origin == "Random Search" else
+                   "Local" if (c.origin == "Local Search" or
+                               c.origin == "Random Search (sorted)") else
                    "Unknown" for c in conf_list]
         source.add(conf_types, 'type')
         source.add(origins, 'origin')

--- a/cave/utils/tooltips.py
+++ b/cave/utils/tooltips.py
@@ -1,7 +1,9 @@
 def get_tooltip(header):
     tooltips = {
         "Meta Data": "Meta data, i.e. number of instances and "
-                     "parameters as well as configuration budget.",
+                     "parameters as well as configuration budget. "
+                     "Statistics apply to the best run, if multiple "
+                     "configurator runs are compared.",
 
         "Best configuration": "Comparing parameters of default and incumbent. "
                               "Parameters that differ from default to "

--- a/cave/utils/tooltips.py
+++ b/cave/utils/tooltips.py
@@ -82,7 +82,15 @@ def get_tooltip(header):
                                   "evaluated configurations. The larger the "
                                   "dot, the more often the configuration was "
                                   "evaluated on instances from the set. "
-                                  "The colours correspond to the predicted "
+                                  "Configurations that were incumbents at least "
+                                  "once during optimization are marked as red "
+                                  "squares. "
+                                  "Configurations acquired through local search "
+                                  "are marked with a 'x'. "
+                                  "The downward triangle denotes the final "
+                                  "incumbent, whereas the orange upward triangle "
+                                  "denotes the default configuration. "
+                                  "The heatmap and the colorbar correspond to the predicted "
                                   "performance in that part of the search "
                                   "space.",
 


### PR DESCRIPTION
fix timeouts in performance-table
combine local search and random search (sorted) in configurator footprint
fix `min_runs` in meta-info by fixing all statistics there to the best run (adding comparison all/best/worst in next update)
fix tooltip for conf-footprint
fix threshold for lpi-entries