### PR TITLE
FIX #225 by ignoring forbidden clauses in surface prediction in cfp

### DIFF
--- a/cave/plot/configurator_footprint.py
+++ b/cave/plot/configurator_footprint.py
@@ -183,8 +183,8 @@ class ConfiguratorFootprintPlotter(object):
 
         # impute missing values in configs and insert MDS'ed (2dim) configs to the right positions
         conf_dict = {}
-        # Remove forbidden clauses (because this is not relevant here)
-        cs_no_forbidden = conf_list[0].configuration_space
+        # Remove forbidden clauses (this is necessary to enable the impute_inactive_values-method, see #226)
+        cs_no_forbidden = copy.deepcopy(conf_list[0].configuration_space)
         cs_no_forbidden.forbidden_clauses = []
         for idx, c in enumerate(conf_list):
             c.configuration_space = cs_no_forbidden

--- a/cave/plot/configurator_footprint.py
+++ b/cave/plot/configurator_footprint.py
@@ -183,7 +183,11 @@ class ConfiguratorFootprintPlotter(object):
 
         # impute missing values in configs and insert MDS'ed (2dim) configs to the right positions
         conf_dict = {}
+        # Remove forbidden clauses (because this is not relevant here)
+        cs_no_forbidden = conf_list[0].configuration_space
+        cs_no_forbidden.forbidden_clauses = []
         for idx, c in enumerate(conf_list):
+            c.configuration_space = cs_no_forbidden
             conf_list[idx] = impute_inactive_values(c)
             conf_dict[str(conf_list[idx].get_array())] = X_scaled[idx, :]
 
@@ -253,6 +257,7 @@ class ConfiguratorFootprintPlotter(object):
         depth = np.array(depth)
 
         # TODO tqdm
+        start = time.time()
         for i in range(n_confs):
             for j in range(i + 1, n_confs):
                 dist = np.abs(conf_matrix[i, :] - conf_matrix[j, :])
@@ -262,7 +267,8 @@ class ConfiguratorFootprintPlotter(object):
                 dists[i, j] = np.sum(dist)
                 dists[j, i] = np.sum(dist)
             if 5 < n_confs and i % (n_confs // 5) == 0:
-                self.logger.debug("%.2f%% of all distances calculated...", 100 * i / n_confs)
+                self.logger.debug("%.2f%% of all distances calculated in %.2f seconds...", 100 * i / n_confs,
+                                                                                         time.time() - start)
 
         return dists
 


### PR DESCRIPTION
Fix issue #225 by deleting forbidden clauses from the configspace that is used to generate the prediction surface in the configurator footprint.